### PR TITLE
Error handling in Kafka Consumer Actor

### DIFF
--- a/akka/build.sbt
+++ b/akka/build.sbt
@@ -14,6 +14,7 @@ libraryDependencies ++= Seq(
   "org.scala-lang" % "scala-reflect" % "2.11.7",
 
   "com.typesafe.akka" %% "akka-testkit" % versions.akka % "test",
+  "com.typesafe.akka" %% "akka-slf4j" % versions.akka % "test",
   "org.scalatest" %% "scalatest" % versions.scalaTest % "test",
   "ch.qos.logback" % "logback-classic" % "1.1.3" % "test"
 )

--- a/akka/src/it/resources/application.conf
+++ b/akka/src/it/resources/application.conf
@@ -13,6 +13,22 @@ consumer {
   enable.auto.commit = false
   auto.offset.reset = "earliest"
   max.partition.fetch.bytes = "256000"
-  schedule.interval = 3000
+  schedule.interval = 100
   unconfirmed.timeout = 0
+  retryStrategy {
+    interval {
+      type = "linear"
+      duration = 100
+    }
+    logic {
+      type = finiteTimes
+      retryCount = 10
+    }
+  }
+}
+
+akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  loglevel = "DEBUG"
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
 }

--- a/akka/src/main/scala/cakesolutions/kafka/akka/Retry.scala
+++ b/akka/src/main/scala/cakesolutions/kafka/akka/Retry.scala
@@ -1,0 +1,117 @@
+package cakesolutions.kafka.akka
+
+import akka.actor.{Actor, Stash}
+import com.typesafe.config.Config
+
+import scala.concurrent.duration._
+
+object Retry {
+
+  sealed trait Interval {
+    def duration: FiniteDuration
+    def next: Interval
+  }
+
+  object Interval {
+    import scala.concurrent.duration.{MILLISECONDS => Millis}
+    private def durationFromConfig(config: Config, path: String) = Duration(config.getDuration(path, Millis), Millis)
+
+    def apply(config: Config): Interval =
+      config.getString("type").toLowerCase match {
+        case "linear" => Linear(durationFromConfig(config, "duration"))
+        case t => sys.error(s"Unexpected interval type: $t")
+      }
+
+    case class Linear(duration: FiniteDuration) extends Interval {
+      def next: Interval = this
+    }
+  }
+
+  sealed trait Logic {
+    def next: Logic
+    def isFinished: Boolean
+  }
+
+  object Logic {
+    def apply(config: Config): Logic =
+      config.getString("type").toLowerCase match {
+        case "infinite" => Infinite
+        case "finitetimes" => FiniteTimes(config.getInt("retryCount"))
+        case t => sys.error(s"Unexpected logic type: $t")
+      }
+
+    case object Infinite extends Logic {
+      def next: Logic = Infinite
+      def isFinished: Boolean = false
+    }
+
+    case class FiniteTimes(retryCount: Int) extends Logic {
+      require(retryCount >= 0, "Retry count cannot be negative")
+
+      def next: Logic = FiniteTimes(retryCount - 1)
+      def isFinished: Boolean = retryCount == 0
+    }
+  }
+
+  object Strategy {
+    def apply(config: Config): Strategy =
+      Strategy(
+        Interval(config.getConfig("interval")),
+        Logic(config.getConfig("logic"))
+      )
+  }
+
+  case class Strategy(interval: Interval, retryLogic: Logic) {
+    def next: Strategy = Strategy(interval.next, retryLogic.next)
+    def isFinished: Boolean = retryLogic.isFinished
+    def evaluate[T](f: => T): Result[T] =
+      try {
+        Result.Success(f)
+      } catch {
+        case error: Exception =>
+          val nextStrategy = this.next
+          if (nextStrategy.isFinished) Result.Failure(error)
+          else Result.Next(error, nextStrategy)
+      }
+  }
+
+  sealed trait Result[+T]
+
+  object Result {
+    case class Next(error: Throwable, strategy: Strategy) extends Result[Nothing]
+    case class Failure(error: Throwable) extends Result[Nothing]
+    case class Success[+T](value: T) extends Result[T]
+  }
+}
+
+object ActorWithInternalRetry {
+  case object CooldownDone
+}
+
+trait ActorWithInternalRetry extends Actor with Stash {
+
+  import ActorWithInternalRetry._
+  import Retry._
+  import context.dispatcher
+
+  def evaluateUntilFinished(strategy: Strategy, recover: Throwable => Unit)(effect: => Unit): Unit =
+    strategy.evaluate(effect) match {
+      case Result.Success(_) => unstashAll()
+      case Result.Failure(error) => throw error
+      case Result.Next(error, nextStrategy) =>
+        recover(error)
+        scheduleCooldown(nextStrategy)
+        context.become(cooldownReceive(nextStrategy, recover, effect), discardOld = false)
+    }
+
+  private def scheduleCooldown(strategy: Strategy): Unit =
+    context.system.scheduler.scheduleOnce(strategy.interval.duration, self, CooldownDone)
+
+  private def cooldownReceive(strategy: Strategy, recover: Throwable => Unit, effect: => Unit): Receive = {
+    case CooldownDone =>
+      context.unbecome()
+      evaluateUntilFinished(strategy, recover)(effect)
+
+    case _ => stash()
+  }
+}

--- a/akka/src/test/resources/logback.xml
+++ b/akka/src/test/resources/logback.xml
@@ -13,7 +13,7 @@
     <logger name="kafka.utils" level="WARN" />
     <logger name="org.apache.kafka" level="INFO" />
     <logger name="kafka" level="INFO" />
-    <logger name="cakesolutions" level="DEBUG" />
+    <logger name="cakesolutions" level="INFO" />
 
     <root level="DEBUG">
         <appender-ref ref="STDOUT" />

--- a/akka/src/test/scala/cakesolutions/kafka/akka/ActorWithInternalRetrySpec.scala
+++ b/akka/src/test/scala/cakesolutions/kafka/akka/ActorWithInternalRetrySpec.scala
@@ -1,0 +1,131 @@
+package cakesolutions.kafka.akka
+
+import akka.actor.SupervisorStrategy.{Restart, Resume}
+import akka.actor.{Actor, ActorRef, ActorSystem, OneForOneStrategy, Props, SupervisorStrategy}
+import akka.testkit.{TestKit, TestProbe}
+import cakesolutions.kafka.akka.Retry.Strategy
+import org.scalatest.{FlatSpecLike, Matchers}
+
+import scala.concurrent.duration._
+
+class ActorWithInternalRetrySpec(system_ : ActorSystem) extends TestKit(system_) with FlatSpecLike with Matchers {
+
+  import Retry._
+
+  def this() = this(ActorSystem("ActorWithInternalRetrySpec"))
+
+  val defaultStrategy = Strategy(Interval.Linear(0.millis), Logic.Infinite)
+
+  "ActorWithInternalRetry" should "be able to succeed on first try" in {
+    val probe = TestProbe()
+    val actor = sampleActor(probe.ref)
+
+    probe.send(actor, (0, defaultStrategy))
+
+    probe.expectMsg(List('start, 'success))
+  }
+
+  it should "retry if it doesn't succeed" in {
+    val probe = TestProbe()
+    val actor = sampleActor(probe.ref)
+
+    probe.send(actor, (3, defaultStrategy))
+
+    probe.expectMsg(statesSequence(3, success = true))
+  }
+
+  it should "not succeed when it exceeds retries" in {
+    val probe = TestProbe()
+    val actor = sampleActor(probe.ref)
+    val strategy = defaultStrategy.copy(retryLogic = Logic.FiniteTimes(7))
+
+    probe.send(actor, (10, strategy))
+
+    probe.expectMsg('exception)
+
+    probe.send(actor, 'get)
+
+    probe.expectMsg((4, statesSequence(6, success = false)))
+  }
+
+  it should "not answer to new messages until it finishes the computation" in {
+    val probe = TestProbe()
+    val actor = sampleActor(probe.ref)
+    val strategy = defaultStrategy.copy(Interval.Linear(100.millis))
+    val expectedResult = statesSequence(10, success = true)
+
+    probe.send(actor, (10, strategy))
+    probe.send(actor, 'get)
+
+    probe.expectMsg(expectedResult)
+    probe.expectMsg((0, expectedResult))
+  }
+
+  private def statesSequence(recoveries: Int, success: Boolean) = {
+    val finalState = if (success) 'success else 'fail
+    'start :: failRecover(recoveries) ++ (finalState :: Nil)
+  }
+
+  private def failRecover(times: Int) =
+    (1 to times).flatMap(_ => List('fail, 'recover)).toList
+
+  private def sampleActor(nextActor: ActorRef) = system.actorOf(Props(classOf[SampleRetrySupervisor], nextActor))
+}
+
+class SampleRetrySupervisor(nextActor: ActorRef) extends Actor {
+  override def supervisorStrategy: SupervisorStrategy = OneForOneStrategy() {
+    case _: SampleException =>
+      nextActor ! 'exception
+      Resume
+    case _ => Restart
+  }
+
+  private val actor = context.actorOf(Props[SampleRetryActor])
+
+  def receive: Receive = {
+    case m => actor forward m
+  }
+}
+
+class SampleRetryActor extends ActorWithInternalRetry {
+
+  // state that makes `doStuff` fail. recovery attempts to "correct" the state.
+  private var failTimes: Int = 0
+
+  // log of states
+  private var states: List[Symbol] = Nil
+
+  def receive: Receive = {
+    case (timesToFail: Int, strategy: Strategy) =>
+      failTimes = timesToFail
+      pushState('start)
+      val s = sender()
+      evaluateUntilFinished(strategy, recovery) {
+        doStuff(s)
+      }
+
+    case 'get => sender() ! (failTimes, getState)
+  }
+
+  private def pushState(state: Symbol): Unit = {
+    states = state :: states
+  }
+
+  private def recovery(t: Throwable): Unit = {
+    failTimes -= 1
+    pushState('recover)
+  }
+
+  private def doStuff(ref: ActorRef): Unit =
+    if (failTimes == 0) {
+      pushState('success)
+      ref ! getState
+    } else {
+      pushState('fail)
+      throw new SampleException
+    }
+
+  private def getState = states.reverse
+}
+
+class SampleException extends Exception

--- a/akka/src/test/scala/cakesolutions/kafka/akka/KafkaConsumerActorSpec.scala
+++ b/akka/src/test/scala/cakesolutions/kafka/akka/KafkaConsumerActorSpec.scala
@@ -16,7 +16,8 @@ object KafkaConsumerActorSpec {
     KafkaProducer(new StringSerializer(), new StringSerializer(), bootstrapServers = kafkaHost + ":" + kafkaPort)
 
   def actorConf(topic: String): KafkaConsumerActor.Conf = {
-    KafkaConsumerActor.Conf(List(topic))
+    import Retry._
+    KafkaConsumerActor.Conf(List(topic), retryStrategy = Strategy(Interval.Linear(1.seconds), Logic.FiniteTimes(10)))
   }
 }
 
@@ -56,6 +57,16 @@ class KafkaConsumerActorSpec(system: ActorSystem) extends KafkaIntSpec(system) {
          | schedule.interval = 3000 milliseconds
          | unconfirmed.timeout = 3000 milliseconds
          | buffer.size = 8
+         | retryStrategy {
+         |   interval {
+         |     type = "linear"
+         |     duration = 1000
+         |   }
+         |   logic {
+         |     type = finiteTimes
+         |     retryCount = 10
+         |   }
+         | }
         """.stripMargin)
     )
 
@@ -70,6 +81,16 @@ class KafkaConsumerActorSpec(system: ActorSystem) extends KafkaIntSpec(system) {
          | schedule.interval = 3000 milliseconds
          | unconfirmed.timeout = 3000 milliseconds
          | buffer.size = 8
+         | retryStrategy {
+         |   interval {
+         |     type = "linear"
+         |     duration = 1000
+         |   }
+         |   logic {
+         |     type = finiteTimes
+         |     retryCount = 10
+         |   }
+         | }
         """.stripMargin)
   }
 

--- a/client/src/main/scala/cakesolutions/kafka/KafkaProducer.scala
+++ b/client/src/main/scala/cakesolutions/kafka/KafkaProducer.scala
@@ -50,20 +50,12 @@ class KafkaProducer[K, V](val producer: JKafkaProducer[K, V]) {
 
   def send(record: ProducerRecord[K, V]): Future[RecordMetadata] = {
     val promise = Promise[RecordMetadata]()
-    logSend(record)
     producer.send(record, producerCallback(promise))
     promise.future
   }
 
   def sendWithCallback(record: ProducerRecord[K, V])(callback: Try[RecordMetadata] => Unit): Unit = {
-    logSend(record)
     producer.send(record, producerCallback(callback))
-  }
-
-  private def logSend(record: ProducerRecord[K, V]): Unit = {
-    val key = Option(record.key()).map(_.toString).getOrElse("null")
-    log.info("Sending message to topic=[{}], key=[{}], value=[{}]",
-      record.topic(), key, record.value().toString)
   }
 
   def flush(): Unit = {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.5.1"
+version in ThisBuild := "0.5.2-SNAPSHOT"


### PR DESCRIPTION
- Addresses the problems mentioned in issue #12.
- Only offsets that can be committed will be committed. Repartitioning can occur before commit, which might cause commit to be rejected.
- Kafka operations (commit, poll) are retried on error. If an error occurs, the consumer is recreated, and the operation will be tried again. Retry strategy can be customized by the user. For now, there are only simple strategies available.